### PR TITLE
Sandbox iframes

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -92,6 +92,7 @@ function applySettingsToNudel(settings) {
         Frame.strudel = document.createElement('iframe');
         Frame.strudel.src = '/strudel';
         Frame.strudel.id = 'strudel';
+        Frame.strudel.sandbox = 'allow-scripts allow-same-origin';
         document.body.appendChild(Frame.strudel);
       }
     } else {
@@ -111,6 +112,7 @@ function applySettingsToNudel(settings) {
         Frame.hydra = document.createElement('iframe');
         Frame.hydra.src = '/hydra';
         Frame.hydra.id = 'hydra';
+        Frame.hydra.sandbox = 'allow-scripts allow-same-origin';
         document.body.appendChild(Frame.hydra);
       }
     } else {


### PR DESCRIPTION
This prevents things like `alert` abuse, and networking to external naughty things, and a lot more.

It *will* prevent some kinds of desired features, eg: importing external libraries. but we can always add exceptions for things like that.

Fixes #7 


---

For those wondering, using the `sandbox` attribute flips how iframe permissions work. By default, everything is disallowed, and you have to specify what things you *do* allow.

There's a chance this breaks some things, so we should keep an eye on any bugs